### PR TITLE
Feat/query parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,6 @@ cython_debug/
 
 # development db
 bypc.db
+components.db
+
 .DS_Store

--- a/build-your-pc/main.py
+++ b/build-your-pc/main.py
@@ -137,5 +137,23 @@ async def static(path):
     return await send_from_directory("static", path)
 
 
+@app.route("/components/<kind>")
+async def get_components(kind: str):
+    try:
+        print(kind.strip())
+        # NOTE: This would normally be unsafe, but since we validate
+        # component above it's fine to directly concatenate the component
+        # into the SQL string.
+        return await cfg.get_components(kind.strip())
+    except util.InvalidComponentType as e:
+        return (
+            {
+                "cause": f"Invalid pc component type given.",
+                "error": e.__class__.__name__,
+            },
+            404,
+        )
+
+
 if __name__ == "__main__":
     app.run()

--- a/build-your-pc/migrations/scripts/03create_partlist.py
+++ b/build-your-pc/migrations/scripts/03create_partlist.py
@@ -1,0 +1,35 @@
+async def run(db_conn):
+    await db_conn.execute(
+        """
+        CREATE TABLE part_list (
+            id INTEGER PRIMARY KEY,
+            components_name TEXT ,
+            users_id INTEGER,
+            FOREIGN KEY (components_name) REFERENCES component (name),
+            FOREIGN KEY (users_id) REFERENCES users (id)
+        )
+        """
+    )
+    await db_conn.execute(
+        """
+        ALTER TABLE component
+        ADD COLUMN kind TEXT NOT NULL
+        """
+    )
+    for i in ["cpu", "case", "motherboard", "gpu", "psu"]:
+        await db_conn.execute(
+            f"""
+            UPDATE component
+            SET kind = '{i}'
+            WHERE name = (SELECT name FROM {i}s)
+            """
+        )
+    await db_conn.execute(
+        """
+        UPDATE component
+        SET kind = 'memory'
+        WHERE name in (SELECT name FROM memory)
+        """
+    )
+
+    await db_conn.commit()

--- a/build-your-pc/migrations/scripts/04rename_to_singular.py
+++ b/build-your-pc/migrations/scripts/04rename_to_singular.py
@@ -1,0 +1,39 @@
+import re
+
+
+async def run(db_conn):
+    await db_conn.commit()
+    for i in ["cpus", "cases", "motherboards", "gpus", "psus", "memory"]:
+        create_tbl_stmt_preprocessed = await db_conn.execute(
+            """
+            SELECT sql FROM sqlite_master WHERE type='table' AND name=?
+            """,
+            (i,),
+        )
+
+        _new_table_name = r"\1\2" if i != "cases" else "chassis"
+
+        create_tbl_stmt = re.sub(
+            r"CREATE TABLE (?:(\S*)s|(memory)) \(",
+            f"CREATE TABLE pc.{_new_table_name} (",
+            (await create_tbl_stmt_preprocessed.fetchone())[0],
+        )
+
+        await db_conn.execute(
+            # make it singular if you can, and recreate the table that was in the main db until now.
+            create_tbl_stmt
+        )
+        await db_conn.execute(
+            f"""
+            INSERT INTO pc.{ i if i == "memory" else
+                             "chassis" if i == "cases" 
+                             else i[:-1] } SELECT * FROM {i}
+            """
+        )
+
+        await db_conn.execute(
+            f"""
+            DROP TABLE {i}
+            """
+        )
+    await db_conn.commit()

--- a/build-your-pc/util.py
+++ b/build-your-pc/util.py
@@ -7,6 +7,7 @@ from tomllib import load
 from dataclasses import dataclass
 import uuid
 import time
+from typing import Literal
 
 from migrations import migrate
 
@@ -23,6 +24,11 @@ class UserAlreadyExists(Error):
 
 
 class WrongUsernameOrPassword(Error):
+    def __init__(self):
+        pass
+
+
+class InvalidComponentType(Error):
     def __init__(self):
         pass
 
@@ -117,3 +123,18 @@ class Config:
         user = User(user["username"], user["id"])
         token = await self._generate_token(username)
         return (user, token)
+
+    async def get_components(
+        self, kind: Literal["cpu", "gpu", "psu", "memory", "chassis", "motherboard"]
+    ):
+        if kind not in [
+            "cpu",
+            "memory",
+            "gpu",
+            "case",
+            "motherboard",
+            "psu",
+        ]:
+            raise InvalidComponentType()
+        results = await self._db_conn.execute(f"SELECT * FROM pc.{kind}")
+        return [dict(item) for item in await results.fetchall()]

--- a/build-your-pc/util.py
+++ b/build-your-pc/util.py
@@ -55,6 +55,7 @@ class Config:
 
     async def init(self):
         await self._db_conn
+        await self._db_conn.execute("ATTACH 'components.db' AS pc")
         self._db_conn.row_factory = aiosqlite.Row
         await migrate(self._db_conn)
 


### PR DESCRIPTION
The migrations to moving everything to a second db in bf81094 is kind of a hideous nightmare, and 3a41f could really just be it's own PR (that stuff isn't really even used right now) - but I kinda don't care. 2299a7c works fine.

We should either probably get rid of the `components` table or turn it into a view, but that'd take nightmare SQL to do.

Edit: also no pagination, but that should (hopefully) be easy to add. 